### PR TITLE
Phase banner include as HTML for OPG guidance

### DIFF
--- a/docs/_includes/components/phase-banner.html
+++ b/docs/_includes/components/phase-banner.html
@@ -1,8 +1,11 @@
 <div class="nhsuk-phase-banner" id="{{include.phase_id}}">
   <div class="nhsuk-width-container">
     <p class="nhsuk-phase-banner__content">
-      <strong class="nhsuk-tag">{{include.phase_tag}}</strong>
-      <span class="nhsuk-phase-banner__text">{{include.phase_text}}</span>
+      <strong class="nhsuk-tag">NEWS</strong>
+      <span class="nhsuk-phase-banner__text">NHS announces move to digital-first messaging.
+        <a class="nhsuk-link" href="https://notify.nhs.uk/using-nhs-notify/nhs-digital-first-strategy">Send messages with the NHS App first using NHS
+          Notify</a>.
+      </span>
     </p>
   </div>
 </div>

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -1,7 +1,8 @@
 <header class="nhsuk-header" role="banner">
   <div class="nhsuk-header__container">
     <div class="nhsuk-header__logo">
-      <a class="nhsuk-header__link nhsuk-header__link--service" href="{{ site.baseurl }}/" aria-label="NHS Notify homepage">
+      <a class="nhsuk-header__link nhsuk-header__link--service" href="{{ site.baseurl }}/"
+        aria-label="NHS Notify homepage">
         <svg class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 16" height="40" width="100">
           <path class="nhsuk-logo__background" fill="#005eb8" d="M0 0h40v16H0z"></path>
           <path class="nhsuk-logo__text" fill="#fff"
@@ -17,4 +18,5 @@
   <div class="nhsuk-navigation-container">
     {%- include primary-navigation.html -%}
   </div>
+  {%- include components/phase-banner.html -%}
 </header>

--- a/docs/pages/get-started/(draft)onboard-with-notify.md
+++ b/docs/pages/get-started/(draft)onboard-with-notify.md
@@ -173,7 +173,7 @@ text='Your organisation or service will need to accept that it’s responsible f
 - managing the volume of messages it sends so it does not exceed any previously agreed amounts
 
 You also need to confirm that you have successfully completed integration testing with NHS Notify.'
-  %}
+%}
 
 {% include components/details.html
 heading='Prove you have developed your integration securely'


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This PR adds a phase banner that shows users the announcement for NHS digital-first strategy and links to `/using-nhs-notify/nhs-digital-first-strategy`.

## Context

This banner acts as a CTA for new prospects who might come to the NHS Notify website following the announcement. 

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
