### PR TITLE
 CCM-10850: add sidebar section ordering

### DIFF
--- a/docs/_data/sidebar-section-order.yml
+++ b/docs/_data/sidebar-section-order.yml
@@ -1,0 +1,9 @@
+# Section ordering for sidebar navigation
+# Add sections in the order you want them to appear
+# Sections not listed here will appear at the end in alphabetical order
+
+sections:
+  - "By use case"
+  - "Accessing NHS Notify"
+  - "Writing a message"
+  - "Sending a message"

--- a/docs/_layouts/page.html
+++ b/docs/_layouts/page.html
@@ -16,8 +16,36 @@ assign nav_pages = site.pages
 assign first_level = nav_pages
 | where_exp: "item", "item.dir == first_level_dir"
 | group_by: "section"
-| sort: 'name', 'last'
 -%}
+
+{%- assign section_order = site.data.sidebar-section-order.sections -%}
+
+{%- assign ordered_sections = "" | split: "" -%}
+{%- for section_name in section_order -%}
+  {%- for section in first_level -%}
+    {%- if section.name == section_name -%}
+      {%- assign ordered_sections = ordered_sections | push: section -%}
+      {%- break -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endfor -%}
++
+{%- comment -%}
+Add any sections not in the manual order list at the end
+{%- endcomment -%}
+{%- for section in first_level -%}
+  {%- assign found = false -%}
+  {%- for ordered_section in ordered_sections -%}
+    {%- if section.name == ordered_section.name -%}
+      {%- assign found = true -%}
+      {%- break -%}
+    {%- endif -%}
+  {%- endfor -%}
+  {%- unless found -%}
+    {%- assign ordered_sections = ordered_sections | push: section -%}
+  {%- endunless -%}
+{%- endfor -%}
+
 <div class="nhsuk-width-container">
   {%- include breadcrumb.html -%}
   <main class="nhsuk-main-wrapper--s" id="maincontent" role="main">
@@ -27,7 +55,7 @@ assign first_level = nav_pages
           <div class="nhsnotify-pane__side-bar">
             <nav class="nhsnotify-side-nav">
               <ul class="nhsuk-list nhsnotify-side-nav__list">
-                {% for section in first_level %}
+                {% for section in ordered_sections %}
                 {% if section.name != "" %}
                 <li class="nhsuk-u-font-weight-bold nhsnotify-side-nav__list-section">{{ section.name }}</li>
                 {% endif %}

--- a/docs/_layouts/page.html
+++ b/docs/_layouts/page.html
@@ -29,7 +29,7 @@ assign first_level = nav_pages
     {%- endif -%}
   {%- endfor -%}
 {%- endfor -%}
-+
+
 {%- comment -%}
 Add any sections not in the manual order list at the end
 {%- endcomment -%}


### PR DESCRIPTION
* Introduced a new YAML file to define the order of sections in the sidebar navigation.
* Updated the page layout to utilize the defined section order, ensuring sections not listed appear at the end in alphabetical order.

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This change implements a configurable sidebar section ordering system for the NHS Notify documentation. A new YAML configuration file (`docs/_data/sidebar-section-order.yml`) has been created to define the preferred order of navigation sections. The page layout template has been updated to read this configuration and display sections in the specified order, with any sections not explicitly listed appearing at the end in alphabetical order.

## Context

The sidebar navigation was previously displaying sections in an arbitrary order, which could be confusing for users trying to navigate through the documentation. This change provides a structured and predictable navigation experience by allowing explicit control over section ordering while maintaining flexibility for new sections.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.