### PR TITLE
fix(navigation): restore original sidebar order for Features section

### DIFF
--- a/docs/_layouts/page.html
+++ b/docs/_layouts/page.html
@@ -18,11 +18,30 @@ assign first_level = nav_pages
 | group_by: "section"
 -%}
 
+{%- comment -%}
+Separate pages with sections from pages without sections
+{%- endcomment -%}
+{%- assign pages_without_sections = "" | split: "" -%}
+{%- assign pages_with_sections = "" | split: "" -%}
+
+{%- for section in first_level -%}
+  {%- if section.name == "" or section.name == nil -%}
+    {%- assign pages_without_sections = pages_without_sections | concat: section.items -%}
+  {%- else -%}
+    {%- assign pages_with_sections = pages_with_sections | push: section -%}
+  {%- endif -%}
+{%- endfor -%}
+
+{%- comment -%}
+Sort pages without sections by nav_order
+{%- endcomment -%}
+{%- assign sorted_pages_without_sections = pages_without_sections | sort: 'nav_order' -%}
+
 {%- assign section_order = site.data.sidebar-section-order.sections -%}
 
 {%- assign ordered_sections = "" | split: "" -%}
 {%- for section_name in section_order -%}
-  {%- for section in first_level -%}
+  {%- for section in pages_with_sections -%}
     {%- if section.name == section_name -%}
       {%- assign ordered_sections = ordered_sections | push: section -%}
       {%- break -%}
@@ -33,7 +52,7 @@ assign first_level = nav_pages
 {%- comment -%}
 Add any sections not in the manual order list at the end
 {%- endcomment -%}
-{%- for section in first_level -%}
+{%- for section in pages_with_sections -%}
   {%- assign found = false -%}
   {%- for ordered_section in ordered_sections -%}
     {%- if section.name == ordered_section.name -%}
@@ -55,6 +74,25 @@ Add any sections not in the manual order list at the end
           <div class="nhsnotify-pane__side-bar">
             <nav class="nhsnotify-side-nav">
               <ul class="nhsuk-list nhsnotify-side-nav__list">
+                {%- comment -%}
+                First render pages without sections (sorted by nav_order)
+                {%- endcomment -%}
+                {% for post in sorted_pages_without_sections %}
+                {% unless post.has_children %}
+                <li class="
+                      nhsnotify-side-nav__item
+                      {% if post.url == page.url %}
+                        nhsnotify-side-nav__item--current
+                      {% endif %}
+                    ">
+                  <a class="nhsnotify-side-nav__link" href="{{ site.baseurl | append: post.url }}">{{ post.title }}</a>
+                </li>
+                {% endunless %}
+                {% endfor %}
+
+                {%- comment -%}
+                Then render sections with their pages
+                {%- endcomment -%}
                 {% for section in ordered_sections %}
                 {% if section.name != "" %}
                 <li class="nhsuk-u-font-weight-bold nhsnotify-side-nav__list-section">{{ section.name }}</li>


### PR DESCRIPTION
## Description

Fixed sidebar navigation ordering in the Features section to restore the original intended page sequence. The navigation logic was modified to properly handle pages without explicit section assignments by displaying them at the top of the sidebar, sorted by their `nav_order` values, while maintaining sections below in the configured order.

## Context

The new sidebar section logic was unintentionally disrupting the user experience by placing pages without sections (Roadmap and Security) at the bottom of the navigation in alphabetical order, rather than respecting their intended `nav_order` values. This broke the logical information hierarchy that was originally designed for the Features section.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.