### PR TITLE
/pricing fix, plus action link and edit to what the 70p is for on lan…

### DIFF
--- a/docs/_data/home/pricing.yml
+++ b/docs/_data/home/pricing.yml
@@ -11,5 +11,5 @@
   pricing: 2.33p
 
 - heading: Letters
-  description: standard postage
+  description: accessible formats included
   pricing: 70p

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -60,6 +60,10 @@ permalink: /
       </li>
       {% endfor %}
     </ul>
+    {% include components/action-link.html
+        url='/pricing'
+        text='Learn more about pricing'
+      %}
   </div>
 </div>
 

--- a/docs/pages/pricing/letters.md
+++ b/docs/pages/pricing/letters.md
@@ -11,9 +11,11 @@ permalink: /pricing/letters
 
 The cost of sending a standard letter depends on the postage you choose and how many sheets of paper you need.
 
-NHS Notify's standard postage rate is 70p + VAT for one double-sided sheet of paper.
+NHS Notify's standard postage rate is 70p + VAT per letter.
 
-This price includes:
+This is our most cost-effective option. While the cost to send a standard letter is 65p, we charge a blended rate of 70p to cover sending some letters as accessible formats.
+
+Our price includes:
 
 - paper
 - postage
@@ -21,8 +23,6 @@ This price includes:
 - C5 size envelopes with an address window
 - returned letter costs
 - additional charge per letter to cover service costs
-
-This is our most cost-effective option. It's a blended rate that covers sending some letters as accessible formats.
 
 Speak to your onboarding manager if you need:
 

--- a/docs/pages/pricing/pricing.md
+++ b/docs/pages/pricing/pricing.md
@@ -30,7 +30,7 @@ It costs 2.33 pence (plus VAT) for every text message you send.
 
 ## Letters
 
-It costs up to 67p (plus VAT) to send a one-sheet letter with both sides printed using 2nd class postage.
+It costs 70p (plus VAT) to send a letter using NHS Notify's standard postage.
 
 {% include components/action-link.html
     url='/pricing/letters'


### PR DESCRIPTION
…ding page

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This PR includes:

- new action link to /pricing in the pricing section of the landing page - thanks Jake for figuring out how to do this!
- fix to the inaccurate, old 65p letter price on the main /pricing parent page
- changing 'standard postage' to 'accessible formats included' in the card on the landing page, to clarify that it's not the price for standard formats, and that accessible formats are already factored into this price
- updating some content on /pricing/letters to highlight that the standard cost of postage is actually 65p but we charge more due to it being a blended rate - also needed to remove the bit about it being 70p for a single double-sided sheet as technically there'll be an allowance for some users to send more sheets at the same price

## Context

The /pricing parent page change is just to fix an inaccuracy.

The landing page and /pricing/letters changes come as a result of Joe Gamble's concerns that our pricing could be perceived as too high compared to competitors. Joe initially wanted to include the 65p point on the landing page but we were able to persuade him against this as it could be misinterpreted and leave us open to challenge. 

Joe felt strongly that we needed to include the 65p sentence in the other page as he needs a figure to be able to point potential users to. He wants to show what the standard format part of the price so users can compare that more easily.

Joe was happy with the compromise to change the card text and add the new action link to encourage users to read more about our pricing.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
