### PR TITLE
Remove SCAL link

### DIFF
--- a/docs/_includes/custom-components/campaign-feature-list.html
+++ b/docs/_includes/custom-components/campaign-feature-list.html
@@ -417,7 +417,7 @@
         <div class="nhsuk-hint">
           Pay for the messages you send every quarter with cross charging
         </div>
-        <a href="https://notify.nhs.uk/using-nhs-notify/recipients-you-cannot-message">Find out how to pay</a>
+        <a href="https://notify.nhs.uk/pricing/how-to-pay">Find out how to pay</a>
       </td>
       <td class="nhsuk-table__cell">
         <abbr title="Yes">

--- a/docs/_includes/custom-components/direct-message-feature-list.html
+++ b/docs/_includes/custom-components/direct-message-feature-list.html
@@ -448,7 +448,7 @@
         <div class="nhsuk-hint">
           Pay for the messages you send every quarter with cross charging
         </div>
-        <a href="https://notify.nhs.uk/using-nhs-notify/recipients-you-cannot-message">Find out how to pay</a>
+        <a href="https://notify.nhs.uk/pricing/how-to-pay">Find out how to pay</a>
       </td>
       <td class="nhsuk-table__cell">
         <abbr title="Yes">

--- a/docs/_includes/custom-components/transactional-feature-list.html
+++ b/docs/_includes/custom-components/transactional-feature-list.html
@@ -419,7 +419,7 @@
         <div class="nhsuk-hint">
           Pay for the messages you send every quarter with cross charging
         </div>
-        <a href="https://notify.nhs.uk/using-nhs-notify/recipients-you-cannot-message">Find out how to pay</a>
+        <a href="https://notify.nhs.uk/pricing/how-to-pay">Find out how to pay</a>
       </td>
       <td class="nhsuk-table__cell">
         <abbr title="Yes">

--- a/docs/pages/get-started/onboard-with-notify.md
+++ b/docs/pages/get-started/onboard-with-notify.md
@@ -30,7 +30,7 @@ If your organisation or service is invited to onboard, we'll send you an email. 
 
 - what you need to do next
 - an online form to confirm your setup
-- the [Supplier Conformance Assessment List (SCAL)](https://digital.nhs.uk/services/nhs-login/nhs-login-for-partners-and-developers/nhs-login-integration-toolkit/nhs-login-forms-and-documents#supplier-conformance-assessment-list-scal-) you need to complete before you go live
+- the Supplier Conformance Assessment List SCAL you need to complete before you go live
 
 ## 2. Prepare your integration
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This PR fixes some minor errors to some links, including:

- In `/campaigns` `/event-based-messaging` and `/direct-messaging` the 'Find out how to pay' link in Message performance and charging takes you to the wrong destination
- the link to the Supplier Conformance Assessment List (SCAL) takes you to NHS Login's SCAL rather than a generic definition of a SCAL

The link destinations have been corrected or removed where applicable.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
