### PR TITLE
Remove trailing slash and add nav title front matter

### DIFF
--- a/docs/_layouts/page.html
+++ b/docs/_layouts/page.html
@@ -86,7 +86,8 @@ Add any sections not in the manual order list at the end
                         nhsnotify-side-nav__item--current
                       {% endif %}
                     ">
-                  <a class="nhsnotify-side-nav__link" href="{{ site.baseurl | append: post.url }}">{{ post.title }}</a>
+                  <a class="nhsnotify-side-nav__link" href="{{ site.baseurl | append: post.url }}">{{ post.nav_title |
+                    default: post.title }}</a>
                 </li>
                 {% endif %}
                 {% endunless %}
@@ -109,7 +110,8 @@ Add any sections not in the manual order list at the end
                         nhsnotify-side-nav__item--current
                       {% endif %}
                     ">
-                  <a class="nhsnotify-side-nav__link" href="{{ site.baseurl | append: post.url }}">{{ post.title }}</a>
+                  <a class="nhsnotify-side-nav__link" href="{{ site.baseurl | append: post.url }}">{{ post.nav_title |
+                    default: post.title }}</a>
                 </li>
                 {% endif %}
                 {% endunless %}

--- a/docs/pages/about/emails.md
+++ b/docs/pages/about/emails.md
@@ -25,6 +25,6 @@ You might also want to understand more about:
 
 - [email delivery times]({% link pages/using-nhs-notify/delivery-times.md %})
 - [how to tell recipients who your emails are from]({% link pages/using-nhs-notify/tell-recipients-who-your-messages-are-from.md %})
-- [formatting]({% link pages/using-nhs-notify/formatting.md %})
+- [formatting]({% link pages/using-nhs-notify/formatting/formatting-overview.md %})
 - [links and URLs]({% link pages/using-nhs-notify/links-and-urls.md %})
 - [personalisation]({% link pages/using-nhs-notify/personalisation.md %})

--- a/docs/pages/about/letters.md
+++ b/docs/pages/about/letters.md
@@ -38,7 +38,7 @@ You might also want to understand more about:
 - [return addresses]({% link pages/using-nhs-notify/tell-recipients-who-your-messages-are-from.md %})
 - [sending letters to people with access needs]({% link pages/using-nhs-notify/accessible-formats.md %})
 - [sending letters to people who speak other languages]({% link pages/using-nhs-notify/letters-in-other-languages.md %})
-- [formatting]({% link pages/using-nhs-notify/formatting.md %})
+- [formatting]({% link pages/using-nhs-notify/formatting/formatting-overview.md %})
 - [links and URLs]({% link pages/using-nhs-notify/links-and-urls.md %})
 - [personalisation]({% link pages/using-nhs-notify/personalisation.md %})
 

--- a/docs/pages/about/nhs-app-messages.md
+++ b/docs/pages/about/nhs-app-messages.md
@@ -29,7 +29,7 @@ You might also want to understand more about:
 
 - [delivery times for NHS App messages]({% link pages/using-nhs-notify/delivery-times.md %})
 - [how to tell recipients who your NHS App messages are from]({% link pages/using-nhs-notify/tell-recipients-who-your-messages-are-from.md %})
-- [formatting]({% link pages/using-nhs-notify/formatting.md %})
+- [formatting]({% link pages/using-nhs-notify/formatting/formatting-overview.md %})
 - [links and URLs]({% link pages/using-nhs-notify/links-and-urls.md %})
 - [personalisation]({% link pages/using-nhs-notify/personalisation.md %})
 

--- a/docs/pages/about/text-messages.md
+++ b/docs/pages/about/text-messages.md
@@ -27,6 +27,6 @@ You might want to understand more about:
 - [delivery times for text messages]({% link pages/using-nhs-notify/delivery-times.md %})
 - [how to tell audiences who your text messages are from]({% link pages/using-nhs-notify/tell-recipients-who-your-messages-are-from.md %})
 - [sending text messages to international numbers]({% link pages/pricing-and-commercial/text-messages.md %}#sending-text-messages-to-international-numbers)
-- [formatting]({% link pages/using-nhs-notify/formatting.md %})
+- [formatting]({% link pages/using-nhs-notify/formatting/formatting-overview.md %})
 - [links and URLs]({% link pages/using-nhs-notify/links-and-urls.md %})
 - [personalisation]({% link pages/using-nhs-notify/personalisation.md %})

--- a/docs/pages/using-nhs-notify/formatting.md
+++ b/docs/pages/using-nhs-notify/formatting.md
@@ -8,7 +8,7 @@ parent: Using NHS Notify
 nav_order: 2
 permalink: /using-nhs-notify/formatting
 section: Writing a message
-publish: false
+published: false
 ---
 
 NHS Notify uses Markdown to format message content.

--- a/docs/pages/using-nhs-notify/formatting/formatting-overview.md
+++ b/docs/pages/using-nhs-notify/formatting/formatting-overview.md
@@ -1,13 +1,14 @@
 ---
 layout: mini-hub
 title: Overview
+nav_title: Formatting
 nav_order: 1
-permalink: /using-nhs-notify/formatting/
+permalink: /using-nhs-notify/formatting
 section: Writing a message
 mini_hub_topic: Formatting
 mini_hub_pages:
   - title: Overview
-    url:
+    url: /using-nhs-notify/formatting
     current: true
   - title: Bold text
     url: /using-nhs-notify/formatting/bold-text

--- a/docs/pages/using-nhs-notify/using-nhs-notify.md
+++ b/docs/pages/using-nhs-notify/using-nhs-notify.md
@@ -15,7 +15,7 @@ This guidance is to help teams understand how to use NHS Notify.
 
 - [Create and submit a template]({% link pages/using-nhs-notify/create-and-submit-a-template.md %})
 - [Upload a letter]({% link pages/using-nhs-notify/upload-a-letter.md %})
-- [Formatting]({% link pages/using-nhs-notify/formatting.md %})
+- [Formatting]({% link pages/using-nhs-notify/formatting/formatting-overview.md %})
 - [Links and URLs]({% link pages/using-nhs-notify/links-and-urls.md %})
 - [Personalisation]({% link pages/using-nhs-notify/personalisation.md %})
 - [Accessible formats]({% link pages/using-nhs-notify/accessible-formats.md %})


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

I have:

- removed the trailing slash from the URL in the front matter
- added nav_title: Formatting to the front matter to ensure 'Formatting' not 'Overview' gets pulled into the side nav
- updated the links to the formatting page to include the correct folder structure

## Context

The formatting mini hub changes aren't appearing on the live site with the regular /formatting URL, despite it looking fine in the local environment. This attempts to fix that.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
