### PR TITLE
removed trailing / from links back to overview

### DIFF
--- a/docs/pages/using-nhs-notify/formatting/formatting-bold.md
+++ b/docs/pages/using-nhs-notify/formatting/formatting-bold.md
@@ -6,7 +6,7 @@ permalink: /using-nhs-notify/formatting/bold-text
 mini_hub_topic: Formatting
 mini_hub_pages:
   - title: Overview
-    url: /using-nhs-notify/formatting/
+    url: /using-nhs-notify/formatting
   - title: Bold text
     url:
     current: true

--- a/docs/pages/using-nhs-notify/formatting/formatting-bullet.md
+++ b/docs/pages/using-nhs-notify/formatting/formatting-bullet.md
@@ -6,7 +6,7 @@ permalink: /using-nhs-notify/formatting/bullet-points-numbered-lists
 mini_hub_topic: Formatting
 mini_hub_pages:
   - title: Overview
-    url: /using-nhs-notify/formatting/
+    url: /using-nhs-notify/formatting
   - title: Bold text
     url: /using-nhs-notify/formatting/bold-text
   - title: Bullet points and numbered lists

--- a/docs/pages/using-nhs-notify/formatting/formatting-fonts.md
+++ b/docs/pages/using-nhs-notify/formatting/formatting-fonts.md
@@ -6,7 +6,7 @@ permalink: /using-nhs-notify/formatting/letter-fonts
 mini_hub_topic: Formatting
 mini_hub_pages:
   - title: Overview
-    url: /using-nhs-notify/formatting/
+    url: /using-nhs-notify/formatting
   - title: Bold text
     url: /using-nhs-notify/formatting/bold-text
   - title: Bullet points and numbered lists

--- a/docs/pages/using-nhs-notify/formatting/formatting-headings.md
+++ b/docs/pages/using-nhs-notify/formatting/formatting-headings.md
@@ -6,7 +6,7 @@ permalink: /using-nhs-notify/formatting/headings
 mini_hub_topic: Formatting
 mini_hub_pages:
   - title: Overview
-    url: /using-nhs-notify/formatting/
+    url: /using-nhs-notify/formatting
   - title: Bold text
     url: /using-nhs-notify/formatting/bold-text
   - title: Bullet points and numbered lists

--- a/docs/pages/using-nhs-notify/formatting/formatting-paragraphs.md
+++ b/docs/pages/using-nhs-notify/formatting/formatting-paragraphs.md
@@ -6,7 +6,7 @@ permalink: /using-nhs-notify/formatting/paragraphs
 mini_hub_topic: Formatting
 mini_hub_pages:
   - title: Overview
-    url: /using-nhs-notify/formatting/
+    url: /using-nhs-notify/formatting
   - title: Bold text
     url: /using-nhs-notify/formatting/bold-text
   - title: Bullet points and numbered lists


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Removed trailing / from links back to overview page on all other mini-hub pages.

## Context

Fix broken links.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
