### PR TITLE
Updated content around message status callbacks

### DIFF
--- a/docs/pages/get-started/onboard-with-nhs-notify.md
+++ b/docs/pages/get-started/onboard-with-nhs-notify.md
@@ -50,7 +50,7 @@ text="To see how your messages perform, you can <a href='https://digital.nhs.uk/
 
 If you want to receive realtime message status callbacks, you'll need to:
 
-- decide which [message, channel or supplier statuses](/using-nhs-notify/message-channel-supplier-status) you want to receive
+- decide which [channel or supplier statuses](/using-nhs-notify/message-channel-supplier-status) you want to receive
 - prepare an endpoint URL for your integration
   "
   %}

--- a/docs/pages/using-nhs-notify/message-status.md
+++ b/docs/pages/using-nhs-notify/message-status.md
@@ -40,10 +40,7 @@ If you're sending messages using multiple channels, you'll get an overall status
 Messages can have the following statuses:
 
 | Status             | Description                                                                                                               |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------- |
-| pending_enrichment | NHS Notify is waiting to check and improve the recipient's contact details using the Personal Demographics Service (PDS). |
-| enriched           | NHS Notify has found the recipient's contact details.                                                                     |
-| sending            | The message is in the process of being sent.                                                                              |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------- |                                                                            |
 | delivered          | The message has been successfully delivered.                                                                              |
 | failed             | We have failed to deliver the message.                                                                                    |
 

--- a/scripts/config/vale/styles/config/vocabularies/words/accept.txt
+++ b/scripts/config/vale/styles/config/vocabularies/words/accept.txt
@@ -32,6 +32,7 @@ OAuth
 Octokit
 onboarding
 pending_enrichment
+pending_virus_check
 permanent_failure
 phoneNumber
 Podman
@@ -55,5 +56,6 @@ Trufflehog
 unnotified
 urlset
 validation_failed
+virus_scan_failed
 VSCode
 Wayfinder


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Removed the following statuses and corresponding descriptions in 'Message status' section on [Message channel supplier status](https://notify.nhs.uk/using-nhs-notify/message-channel-supplier-status) page:

* pending_enrichment
* enriched
* sending

Removed reference to choosing message status on the [Onboard with Notify page](https://notify.nhs.uk/get-started/onboard-with-nhs-notify).

## Context

Previously, a new integrator could choose which message status they want to receive as part of their onboarding setup.

This process has now changed - we only offer two message statuses ('delivered' and 'failed') as default. A user can no longer choose pending_enrichment, enriched or sending statuses.

These changes reflect the new process. 

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
