### PR TITLE
Fixed line break

### DIFF
--- a/docs/pages/using-nhs-notify/links-and-urls.md
+++ b/docs/pages/using-nhs-notify/links-and-urls.md
@@ -28,7 +28,7 @@ For NHS App messages and emails, use square brackets around the full URL to make
 Make sure there are no spaces between the brackets or the link will not work. For example:
 
 {% include components/inset-text.html
-  text='`[NHS website](https://www.nhs.uk)`'
+  text='`[https://www.nhs.uk](https://www.nhs.uk)`'
   classes='nhsuk-u-margin-top-2'
 %}
 

--- a/docs/pages/using-nhs-notify/links-and-urls.md
+++ b/docs/pages/using-nhs-notify/links-and-urls.md
@@ -28,7 +28,7 @@ For NHS App messages and emails, use square brackets around the full URL to make
 Make sure there are no spaces between the brackets or the link will not work. For example:
 
 {% include components/inset-text.html
-  text='`[https://www.nhs.uk/example](https://www.nhs.uk/example)`'
+  text='`[NHS website](https://www.nhs.uk)`'
   classes='nhsuk-u-margin-top-2'
 %}
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Changed an example on how to write URLs in Markdown.

Original:
`[https://www.nhs.uk/example](https://www.nhs.uk/example)`

New:
`[https://www.nhs.uk](https://www.nhs.uk)`

## Context

The original example was appearing as two lines on some screens. This suggests a user needs to add a line break to the markdown, which is inaccurate and will not work. The new change includes a shorter example which should keep it on one line.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
