### PR TITLE
Add font embedding content and fix heading typo

### DIFF
--- a/docs/pages/using-nhs-notify/formatting/formatting-fonts.md
+++ b/docs/pages/using-nhs-notify/formatting/formatting-fonts.md
@@ -30,7 +30,9 @@ published: true
 
 The font size for standard letters is 12 points. The font size for large print is 16 points.
 
-NHS Notify prints letters in the font Noto Sans.
+NHS Notify uses Noto Sans as the default font for all letters. Use this font to ensure your letter prints correctly and meets NHS brand standards.
+
+Only use a different font if you have a specific reason not to use NHS branding. You must [embed the font in your file (Microsoft Word)](https://support.microsoft.com/en-gb/office/benefits-of-embedding-custom-fonts-cb3982aa-ea76-4323-b008-86670f222dbc). If your font is not embedded, you will not be able to upload your letter.
 
 ## Download your font
 

--- a/docs/pages/using-nhs-notify/message-plans.md
+++ b/docs/pages/using-nhs-notify/message-plans.md
@@ -20,7 +20,8 @@ You can choose from a list of pre-defined message plans.
 
 For example: NHS App, email, text message, letter.
 
-How fallbacks work
+## How fallbacks work
+
 If we cannot deliver a message through your first choice, we automatically try the next channel in your message plan.
 
 A fallback happens if:


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

I have:

- added a new section on using fonts other than Noto Sans and how to embed them correctly
- fixed a typo on the /message-plans page where I'd not added ## markdown on a heading

## Context

Certain non-NHSE users aren't allowed to use NHS branding. The developers identified problems in the Carbone software where files with fonts that weren't embedded weren't uploading. We need to add content for the workaround while clarifying that you can only use different fonts in exceptional circumstances.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
