### PR TITLE
Remove unnecessary SN step

### DIFF
--- a/docs/pages/using-nhs-notify/upload-a-letter.md
+++ b/docs/pages/using-nhs-notify/upload-a-letter.md
@@ -59,9 +59,8 @@ text='
 1. Go to <a href="https://nhsdigitallive.service-now.com/csm?id=sc_cat_item&sys_id=6cc625151b9fbad083b0a7d0b24bcb11&referrer=recent_items" target="_blank">ServiceNow (opens in a new tab)</a>.
 2. Sign in with your NHS.net account, or register for a Portal account.
 3. In the <b>Description</b> field, include the email address you want the proofs sent to and the name of your letter template.
-4. For the service, select <b>NHS Notify</b> from the drop-down list.
-5. For the service offering, select <b>NHS Notify - letter</b> from the drop-down list.
-6. Attach your Word letter templates directly to the request.
+4. For the service offering, select <b>NHS Notify - letter</b> from the drop-down list.
+5. Attach your Word letter templates directly to the request.
    '
    %}
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Small update to /upload a letter to remove step 4 from the ServiceNow details component.

## Context

Service Ops team let us know that we don't need to tell users to select NHS Notify as the service because with the new, tailored form, this option is pre-selected and greyed out.

I've got a (postponed) session booked with this team to properly review all upcoming ServiceNow guidance to ensure it's accurate.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
