### PR TITLE
Fixed navigation order

### DIFF
--- a/docs/pages/get-started/check-which-features-you-can-get-and-register.md
+++ b/docs/pages/get-started/check-which-features-you-can-get-and-register.md
@@ -1,7 +1,7 @@
 ---
 layout: mini-hub
 title: Check which features you can get and register
-nav_order: 3
+nav_order: 4
 parent: Get started
 permalink: /get-started/check-which-features-you-can-get-and-register
 mini_hub_topic: Answer a few questions to check which features you can get before you register

--- a/docs/pages/get-started/onboard-with-nhs-notify.md
+++ b/docs/pages/get-started/onboard-with-nhs-notify.md
@@ -1,7 +1,7 @@
 ---
 layout: mini-hub
 title: Onboard with NHS Notify
-nav_order: 4
+nav_order: 5
 parent: Get started
 permalink: /get-started/onboard-with-nhs-notify
 mini_hub_topic: You must follow the steps to prepare for integration


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Changed order of items in left hand navigation on /get-started. The order is now correct and follows the order of the mini-hub.

## Context

Page order on left-hand nav was incorrect.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x ] Refactoring (non-breaking change)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- x[ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
