### PR TITLE
Publish new service unavailable page for planned maintenance of web UI

### DIFF
--- a/docs/pages/support/planned-maintenance.md
+++ b/docs/pages/support/planned-maintenance.md
@@ -1,0 +1,30 @@
+---
+# Feel free to add content and custom Front Matter to this file.
+# To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
+
+layout: no-nav-page
+title: Sorry, this service is currently unavailable
+nav_order: 5
+has_children: true
+permalink: /service-unavailable/
+---
+
+We’re carrying out planned updates.
+
+You’ll be able to use the service again soon.
+
+If you reached this page after submitting information, your progress has not been saved. You’ll need to enter the information again when the service is available.
+
+If you need urgent support, <a href="https://nhsdigitallive.service-now.com/csm?id=sc_cat_item&sys_id=6cc625151b9fbad083b0a7d0b24bcb11&referrer=recent_items" target="_blank">submit a case with Service Now (opens in a new tab)</a>.
+
+{% include components/details.html
+heading='How to submit a ServiceNow case'
+text='
+
+1. Go to <a href="https://nhsdigitallive.service-now.com/csm?id=sc_cat_item&sys_id=6cc625151b9fbad083b0a7d0b24bcb11&referrer=recent_items" target="_blank">ServiceNow (opens in a new tab)</a>.
+2. Log in with your NHS.net account, or register for a Portal account.
+3. In the <b>Description</b> field, include your service name, your full name and the action you were trying to take.
+4. For the <b>service offering</b>, select the relevant option.
+5. Upload any relevant screenshots or documents in the <b>Add attachments</b> section.
+   '
+   %}

--- a/docs/pages/support/planned-maintenance.md
+++ b/docs/pages/support/planned-maintenance.md
@@ -15,7 +15,7 @@ You’ll be able to use the service again soon.
 
 If you reached this page after submitting information, your progress has not been saved. You’ll need to enter the information again when the service is available.
 
-If you need urgent support, <a href="https://nhsdigitallive.service-now.com/csm?id=sc_cat_item&sys_id=6cc625151b9fbad083b0a7d0b24bcb11&referrer=recent_items" target="_blank">submit a case with Service Now (opens in a new tab)</a>.
+If you need urgent support, <a href="https://nhsdigitallive.service-now.com/csm?id=sc_cat_item&sys_id=6cc625151b9fbad083b0a7d0b24bcb11&referrer=recent_items" target="_blank">submit a case with ServiceNow (opens in a new tab)</a>.
 
 {% include components/details.html
 heading='How to submit a ServiceNow case'


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Published a new, 'hidden' page on our website to redirect to from web UI URLs when the service is down for planned maintenance.

This page is located in the /support folder. You need to add the slug /service-unavailable/ on the end to view it (with no 'parent' segment in the URL). For example, the live URL will be https://notify.nhs.uk/service-unavailable/ and the URL to view it on my port was http://127.0.0.1:4000/service-unavailable/

## Context

[CCM-18777](https://nhsd-jira.digital.nhs.uk/browse/CCM-18777)[CCM-18777](https://nhsd-jira.digital.nhs.uk/browse/CCM-18777) explains the context - the tech architects need to do some 'smushing' work, which will make web UI unavailable for around 30 mins.

We're trying to find out exactly when the service will be down so we can add a more detailed line about when it will be available again. In the mean time, Nicki's asked if we can keep the timing more vague. This means that the devs can test the redirect works properly and it gives us a back up option if we can't be specific about timings. When we know more, we can update this page.

We have to publish the service unavailable message on our static site for now because web UI itself will be down so it can't be hosted there.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
